### PR TITLE
Add snsr sensor, expose ovrl sensor, and broaden node devtype matching

### DIFF
--- a/custom_components/ducobox/api.py
+++ b/custom_components/ducobox/api.py
@@ -360,6 +360,7 @@ class DucoCommunicationPrintApi(DucoApiBase):
                         serialnb=data.get("serialnb"),
                         error=data.get("error"),
                         ovrl=data.get("ovrl"),
+                        snsr=data.get("snsr"),
                         netw=data.get("netw"),
                         cntdwn=data.get("cntdwn"),
                         endtime=data.get("endtime"),

--- a/custom_components/ducobox/models.py
+++ b/custom_components/ducobox/models.py
@@ -31,6 +31,7 @@ class DucoBoxNodeData:
     serialnb: str | None = None  # Serial number
     error: str | None = None  # Error status
     ovrl: int | None = None  # Override level
+    snsr: int | None = None  # Sensor demand value (%)
     netw: str | None = None  # Network type (WI = wired, RF = radio frequency)
     cntdwn: int | None = None  # Countdown timer
     endtime: int | None = None  # End time timestamp

--- a/custom_components/ducobox/number.py
+++ b/custom_components/ducobox/number.py
@@ -208,12 +208,11 @@ async def async_setup_entry(  # noqa: PLR0915
     # Add node-specific configuration entities
     if coordinator.data and coordinator.data.nodes:
         for node in coordinator.data.nodes:
-            # Add configuration entities for UCCO2 and UCRH nodes
-            if node.devtype and (
-                "UCCO2" in node.devtype
-                or "UCRH" in node.devtype
-                or node.devtype in ("VLVCO2", "VLVCO2RH")
-            ):
+            # Add configuration entities for all UC and VLV node types.
+            # UC family: UC (basic controller), UCCO2 (CO2+temp), UCRH (humidity+temp), UCBAT (battery).
+            # VLV family: VLV (valve only), VLVCO2 (valve+CO2+temp), VLVCO2RH (valve+CO2+humidity+temp).
+            # Only entities for params actually present in the node config are created.
+            if node.devtype and ("UC" in node.devtype or "VLV" in node.devtype):
                 # Fetch node configuration from the API
                 node_config = await coordinator.api.async_get_node_config(node.node_id)
 

--- a/custom_components/ducobox/sensor.py
+++ b/custom_components/ducobox/sensor.py
@@ -272,6 +272,8 @@ async def async_setup_entry(  # noqa: PLR0915
             or (node.rh is not None and node.rh > 0)
             or node.trgt is not None
             or node.actl is not None
+            or node.ovrl is not None
+            or node.snsr is not None
         )
         if not has_sensors:
             return []
@@ -286,6 +288,10 @@ async def async_setup_entry(  # noqa: PLR0915
             node_entities.append(DucoBoxNodeSensor(coordinator, node, "trgt"))
         if node.actl is not None:
             node_entities.append(DucoBoxNodeSensor(coordinator, node, "actl"))
+        if node.ovrl is not None:
+            node_entities.append(DucoBoxNodeSensor(coordinator, node, "ovrl"))
+        if node.snsr is not None:
+            node_entities.append(DucoBoxNodeSensor(coordinator, node, "snsr"))
         if node.rssi_n2m is not None:
             node_entities.append(DucoBoxNodeSensor(coordinator, node, "rssi"))
         node_entities.append(DucoBoxNodeSensor(coordinator, node, "cerr"))
@@ -380,7 +386,7 @@ class DucoBoxNodeSensor(CoordinatorEntity[DucoBoxCoordinator], RestoreSensor):
 
     _attr_has_entity_name = True
 
-    def __init__(
+    def __init__(  # noqa: PLR0915
         self,
         coordinator: DucoBoxCoordinator,
         node: DucoBoxNodeData,
@@ -439,6 +445,16 @@ class DucoBoxNodeSensor(CoordinatorEntity[DucoBoxCoordinator], RestoreSensor):
             self._attr_icon = "mdi:gauge"
         elif sensor_type == "actl":
             self._attr_translation_key = "node_actl"
+            self._attr_native_unit_of_measurement = PERCENTAGE
+            self._attr_state_class = SensorStateClass.MEASUREMENT
+            self._attr_icon = "mdi:gauge"
+        elif sensor_type == "ovrl":
+            self._attr_translation_key = "node_ovrl"
+            self._attr_native_unit_of_measurement = PERCENTAGE
+            self._attr_state_class = SensorStateClass.MEASUREMENT
+            self._attr_icon = "mdi:gauge"
+        elif sensor_type == "snsr":
+            self._attr_translation_key = "node_snsr"
             self._attr_native_unit_of_measurement = PERCENTAGE
             self._attr_state_class = SensorStateClass.MEASUREMENT
             self._attr_icon = "mdi:gauge"
@@ -501,6 +517,10 @@ class DucoBoxNodeSensor(CoordinatorEntity[DucoBoxCoordinator], RestoreSensor):
                     return node.trgt
                 if self._sensor_type == "actl":
                     return node.actl
+                if self._sensor_type == "ovrl":
+                    return node.ovrl
+                if self._sensor_type == "snsr":
+                    return node.snsr
                 if self._sensor_type == "rssi":
                     return node.rssi_n2m
                 if self._sensor_type == "cerr":

--- a/custom_components/ducobox/translations/en.json
+++ b/custom_components/ducobox/translations/en.json
@@ -207,6 +207,12 @@
             "node_actl": {
                 "name": "Actual Airflow"
             },
+            "node_ovrl": {
+                "name": "Override Level"
+            },
+            "node_snsr": {
+                "name": "Sensor Demand"
+            },
             "node_rssi": {
                 "name": "Signal Strength"
             },


### PR DESCRIPTION
## Summary

- **`snsr` field (Sensor Demand %):** Added `snsr` to `DucoBoxNodeData` model and API parsing; exposed as a new `Sensor Demand` sensor entity per node where present.
- **`ovrl` sensor:** Exposed existing `ovrl` (Override Level %) field as a sensor entity per node where present (it was already in the model but not shown in the UI).
- **Broader node devtype matching in `number.py`:** Replaced the explicit allowlist (`UCCO2`, `UCRH`, `VLVCO2`, `VLVCO2RH`) with a family-based check (`"UC" in devtype or "VLV" in devtype`). This covers the full UC family (UC, UCCO2, UCRH, UCBAT) and VLV family (VLV, VLVCO2, VLVCO2RH) without needing to enumerate every variant. Configuration entities are only created for parameters actually present in the node config, so no regressions for existing node types.

## Test plan

- [ ] Verify `snsr` sensor appears for nodes that return a `snsr` field in `/nodeinfoget`
- [ ] Verify `ovrl` sensor appears for nodes that return an `ovrl` field
- [ ] Verify nodes of types `UC`, `UCBAT`, `VLV` now get configuration entities if their node config contains matching parameters
- [ ] Verify existing `UCCO2` and `UCRH` nodes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)